### PR TITLE
upgrade tunneldigger broker

### DIFF
--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -53,8 +53,13 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
   libevent-dev \
   ebtables \
   vim \
+  iproute \
+  bridge-utils \
+  libnetfilter-conntrack-dev \
+  libnfnetlink-dev \
+  libffi-dev \
+  libevent-dev \
   tmux
-
 
 DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
   cmake \

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -44,7 +44,6 @@ apt-get install -yq \
   dnsmasq \
   procps \
   python-psycopg2 \
-  python-software-properties \
   software-properties-common \
   python \
   python-dev \

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -18,7 +18,6 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes
   libssl-dev \
   libxslt1-dev \
   module-init-tools \
-  bridge-utils \
   openssh-server \
   openssl \
   perl \
@@ -30,11 +29,15 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes
   python \
   python-dev \
   python-pip \
-  iproute \
   libnetfilter-conntrack3 \
-  libevent-dev \
   ebtables \
   vim \
+  iproute \
+  bridge-utils \
+  libnetfilter-conntrack-dev \
+  libnfnetlink-dev \
+  libffi-dev \
+  libevent-dev \
   tmux
 
 KERNEL_VERSION=$(uname -r)
@@ -73,9 +76,12 @@ pip install netfilter
 pip install virtualenv
 
 TUNNELDIGGER_HOME=/opt/tunneldigger
-git clone https://github.com/sudomesh/tunneldigger.git $TUNNELDIGGER_HOME
+git clone https://github.com/jhpoelen/tunneldigger.git $TUNNELDIGGER_HOME
 virtualenv $TUNNELDIGGER_HOME/broker/env_tunneldigger
-$TUNNELDIGGER_HOME/broker/env_tunneldigger/bin/pip install -r $TUNNELDIGGER_HOME/broker/requirements.txt
+cd $TUNNELDIGGER_HOME
+source broker/env_tunneldigger/bin/activate
+cd broker
+python setup.py install
 
 TUNNELDIGGER_UPHOOK_SCRIPT=$TUNNELDIGGER_HOME/broker/scripts/up_hook.sh
 TUNNELDIGGER_DOWNHOOK_SCRIPT=$TUNNELDIGGER_HOME/broker/scripts/down_hook.sh

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -14,14 +14,30 @@ EXITNODE_REPO=jhpoelen/exitnode
 TUNNELDIGGER_REPO=wlanslovenija/tunneldigger
 TUNNELDIGGER_COMMIT=210037aabf8538a0a272661e08ea142784b42b2c
 
-DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes \
+
+KERNEL_VERSION=$(uname -r)
+echo kernel version [$KERNEL_VERSION]
+
+release_info="$(cat /etc/*-release)"
+echo "release_info=$release_info"
+release_name="$(echo $release_info | cut -d'=' -f2)"
+
+if [ "$release_name" == '"Ubuntu"' ]; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
+    linux-image-extra-$(uname -r)
+fi 
+
+apt-get install -yq \
   build-essential \
   ca-certificates \
   curl \
   git \
+  zlib1g \
+  zlib1g-dev \
   libssl-dev \
   libxslt1-dev \
   module-init-tools \
+  bridge-utils \
   openssh-server \
   openssl \
   perl \
@@ -33,33 +49,19 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes
   python \
   python-dev \
   python-pip \
+  iproute \
   libnetfilter-conntrack3 \
+  libevent-dev \
   ebtables \
   vim \
-  iproute \
-  bridge-utils \
-  libnetfilter-conntrack-dev \
-  libnfnetlink-dev \
-  libffi-dev \
-  libevent-dev \
-  tmux \
+  tmux
+
+apt-get install -yq \
   cmake \
   libnl-3-dev \
   libnl-genl-3-dev \
   build-essential \
   pkg-config
-
-KERNEL_VERSION=$(uname -r)
-echo kernel version [$KERNEL_VERSION]
-
-release_info="$(cat /etc/*-release)"
-echo "release_info=$release_info"
-release_name="$(echo $release_info | cut -d'=' -f2)"
-
-if [ $release_name == '"Ubuntu"' ]; then
-  DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
-    linux-image-extra-$(uname -r)
-fi 
 
 mkdir ~/babel_build
 git clone https://github.com/sudomesh/babeld.git ~/babel_build/

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -20,8 +20,8 @@ echo kernel version [$KERNEL_VERSION]
 
 release_info="$(cat /etc/*-release)"
 echo "release_info=$release_info"
-release_name="$(echo $release_info | cut -d'=' -f2)"
-
+release_name="$(echo "$release_info" | grep ^NAME= | cut -d'=' -f2)"
+echo "release_name=[$release_name]"
 DEBIAN_FRONTEND=noninteractive apt-get update
 
 if [ "$release_name" == '"Ubuntu"' ]; then

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -36,7 +36,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
   zlib1g-dev \
   libssl-dev \
   libxslt1-dev \
-  module-init-tools \
+  kmod \
   bridge-utils \
   openssh-server \
   openssl \

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -11,7 +11,8 @@ PUBLIC_IP=$IP
 PUBLIC_SUBNET="$IP/29"
 
 EXITNODE_REPO=jhpoelen/exitnode
-TUNNELDIGGER_REPO=jhpoelen/tunneldigger
+TUNNELDIGGER_REPO=wlanslovenija/tunneldigger
+TUNNELDIGGER_COMMIT=210037aabf8538a0a272661e08ea142784b42b2c
 
 DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes \
   build-essential \
@@ -80,8 +81,9 @@ pip install virtualenv
 
 TUNNELDIGGER_HOME=/opt/tunneldigger
 git clone https://github.com/${TUNNELDIGGER_REPO} $TUNNELDIGGER_HOME
-virtualenv $TUNNELDIGGER_HOME/broker/env_tunneldigger
 cd $TUNNELDIGGER_HOME
+git checkout $TUNNELDIGGER_COMMIT
+virtualenv $TUNNELDIGGER_HOME/broker/env_tunneldigger
 source broker/env_tunneldigger/bin/activate
 cd broker
 python setup.py install

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -27,7 +27,7 @@ if [ "$release_name" == '"Ubuntu"' ]; then
     linux-image-extra-$(uname -r)
 fi 
 
-apt-get install -yq \
+DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
   build-essential \
   ca-certificates \
   curl \
@@ -55,7 +55,8 @@ apt-get install -yq \
   vim \
   tmux
 
-apt-get install -yq \
+
+DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
   cmake \
   libnl-3-dev \
   libnl-genl-3-dev \

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -22,6 +22,8 @@ release_info="$(cat /etc/*-release)"
 echo "release_info=$release_info"
 release_name="$(echo $release_info | cut -d'=' -f2)"
 
+DEBIAN_FRONTEND=noninteractive apt-get update
+
 if [ "$release_name" == '"Ubuntu"' ]; then
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
     linux-image-extra-$(uname -r)

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -42,18 +42,24 @@ DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes
   libnfnetlink-dev \
   libffi-dev \
   libevent-dev \
-  tmux
-
-KERNEL_VERSION=$(uname -r)
-echo kernel version [$KERNEL_VERSION]
-
-DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
+  tmux \
   cmake \
   libnl-3-dev \
   libnl-genl-3-dev \
   build-essential \
-  pkg-config \
-  linux-image-extra-$(uname -r)
+  pkg-config
+
+KERNEL_VERSION=$(uname -r)
+echo kernel version [$KERNEL_VERSION]
+
+release_info="$(cat /etc/*-release)"
+echo "release_info=$release_info"
+release_name="$(echo $release_info | cut -d'=' -f2)"
+
+if [ $release_name == '"Ubuntu"' ]; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -yq --force-yes \
+    linux-image-extra-$(uname -r)
+fi 
 
 mkdir ~/babel_build
 git clone https://github.com/sudomesh/babeld.git ~/babel_build/

--- a/create_exitnode.sh
+++ b/create_exitnode.sh
@@ -10,6 +10,9 @@ ETH_IF=eth0
 PUBLIC_IP=$IP
 PUBLIC_SUBNET="$IP/29"
 
+EXITNODE_REPO=jhpoelen/exitnode
+TUNNELDIGGER_REPO=jhpoelen/tunneldigger
+
 DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq --force-yes \
   build-essential \
   ca-certificates \
@@ -76,7 +79,7 @@ pip install netfilter
 pip install virtualenv
 
 TUNNELDIGGER_HOME=/opt/tunneldigger
-git clone https://github.com/jhpoelen/tunneldigger.git $TUNNELDIGGER_HOME
+git clone https://github.com/${TUNNELDIGGER_REPO} $TUNNELDIGGER_HOME
 virtualenv $TUNNELDIGGER_HOME/broker/env_tunneldigger
 cd $TUNNELDIGGER_HOME
 source broker/env_tunneldigger/bin/activate
@@ -122,7 +125,7 @@ MESHNET="$MESHNET"
 DEFAULT_ROUTE="$(ip route | head -n1 | sed 's/onlink/proto static/g')"
 EOF
 
-git clone https://github.com/sudomesh/exitnode /opt/exitnode
+git clone https://github.com/${EXITNODE_REPO} /opt/exitnode
 cp -r /opt/exitnode/src/etc/* /etc/
 cp /opt/exitnode/l2tp_broker.cfg $TUNNELDIGGER_HOME/broker/l2tp_broker.cfg
 

--- a/l2tp_broker.cfg
+++ b/l2tp_broker.cfg
@@ -17,11 +17,12 @@ tunnel_id_base=100
 ; Tunnel timeout interval in seconds
 tunnel_timeout=60
 ; Should PMTU discovery be enabled
-pmtu_discovery=true
+pmtu=0
 ; Namespace (for running multiple brokers); note that you must also
 ; configure disjunct ports, and tunnel identifiers in order for
 ; namespacing to work
 namespace=experiments
+connection_rate_limit=10
 
 [log]
 ; Log filename

--- a/src/etc/systemd/system/tunneldigger.service
+++ b/src/etc/systemd/system/tunneldigger.service
@@ -5,7 +5,7 @@ After=network.target auditd.service
 [Service]
 Type=simple
 WorkingDirectory=/opt/tunneldigger
-ExecStart=/opt/tunneldigger/broker/env_tunneldigger/bin/python -m broker.main /opt/tunneldigger/broker/l2tp_broker.cfg
+ExecStart=/opt/tunneldigger/broker/env_tunneldigger/bin/python -m tunneldigger_broker.main /opt/tunneldigger/broker/l2tp_broker.cfg
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
Now, a more recent version of tunneldigger is used (i.e., https://github.com/wlanslovenija/tunneldigger/commits/210037aabf8538a0a272661e08ea142784b42b2c) .As discussed in https://github.com/sudomesh/bugs/issues/8 . Exit node script tested on Digital Ocean Ubuntu 16.04 and Debian 9.4 . 