### PR TITLE
support for babeld 1.8.2

### DIFF
--- a/src/etc/profile.d/mesh-tools.sh
+++ b/src/etc/profile.d/mesh-tools.sh
@@ -1,0 +1,2 @@
+export PATH=/opt/mesh-tools/:$PATH
+

--- a/src/etc/systemd/system/babeld.service
+++ b/src/etc/systemd/system/babeld.service
@@ -5,7 +5,7 @@ After=network.target auditd.service
 [Service]
 Type=simple
 WorkingDirectory=/usr/local/bin
-ExecStart=/usr/local/bin/babeld -F -S /var/lib/babeld/state -c /etc/babeld.conf
+ExecStart=/usr/local/bin/babeld -S /var/lib/babeld/state -c /etc/babeld.conf
 KillMode=process
 Restart=on-failure
 PIDFile=/var/run/babeld.pid

--- a/src/etc/systemd/system/babeld.service
+++ b/src/etc/systemd/system/babeld.service
@@ -5,7 +5,7 @@ After=network.target auditd.service
 [Service]
 Type=simple
 WorkingDirectory=/usr/local/bin
-ExecStart=/usr/local/bin/babeld -S /var/lib/babeld/state -c /etc/babeld.conf
+ExecStart=/usr/local/bin/babeld -S /var/lib/babeld/state -c /etc/babeld.conf dummyinterface
 KillMode=process
 Restart=on-failure
 PIDFile=/var/run/babeld.pid

--- a/src/opt/babeld-monitor/babeld-monitor.sh
+++ b/src/opt/babeld-monitor/babeld-monitor.sh
@@ -9,7 +9,7 @@ wait_for_babeld() {
   local try_sleep=5
 
   while [ "$try_count" -lt "$try_max" ]; do
-    babeld -i
+    babeld-info
     local exit_status=$?
     if [[ exit_status -eq 0 ]]; then
       echo "babeld initialized."
@@ -39,8 +39,8 @@ else
     
     # add tunnel interfaces to babeld
     echo "add tunnel interfaces to babeld..."
-    ip addr | tr ' ' '\n' | grep -E "l2tp[0-9\-]+$" | sort | uniq | xargs -L 1 babeld -a 
-    babeld -i | head -n1
+    ip addr | tr ' ' '\n' | grep -E "l2tp[0-9\-]+$" | sort | uniq | xargs -I {} bash -c '(echo "interface {}") | nc -q1 ::1 31337'
+    babeld-info
     echo "add tunnel interfaces to babeld done."
 
     echo "babeld restarted."

--- a/src/opt/mesh-tools/babeld-info
+++ b/src/opt/mesh-tools/babeld-info
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+(echo "dump") | nc -q1 localhost 31337
+


### PR DESCRIPTION
files changed:
- /opt/tunneldigger/broker/scripts/down_hook.sh
- /opt/tunneldigger/broker/scripts/up_hook.sh
- /etc/babeld.conf
- /etc/system/systemd/babeld.service

I made the corresponding changes manually to the HE exit node, but unfortunately I have not tested the create-exitnode.sh script yet. (Would be nice if the way to upgrade the deployed HE node was to simply rerun the create-exitnode.sh script, but I wasn't confident this would work. Does anyone know?)

TODO:
- test the create-exitnode.sh script on a fresh exitnode (any takers?)
- remove or fix babeld-monitor.sh (and its associated systemd units). I broke it with this upgrade--I'm irrationally optimistic that it will solve all of our babeld problems, and that we won't need this monitor anymore.

notes:
- the rogue reconnecting node appears to be back, trying to open tunnels to HE every couple of minutes with tunneldigger id `5fec6d32-83e9-41cf-aaa5-e038fea8d191`. This is sort of convenient because it helps us test whether we continue to see the memory error in https://github.com/sudomesh/bugs/issues/24.
- I had to install netcat-openbsd because the version of netcat on the HE node did not support ipv6 addresses, and babeld -G seems to bind to ipv6 ::1 only.
- `babeld -i` is no longer a thing (same with `-a` and `-x`). The new way to dump babeld state is to communicate with babeld over TCP: `(echo "dump") | nc -q1 ::1 31337`. I'm thinking it would be nice to put this in an easily accessible `babeld-dump.sh` script on the `PATH`. Any suggestions for where such a script ought to live? I imagine we might end up with some kind of  `mesh-tools/` directory with useful debugging/management scripts.

I'm okay to merge as soon as someone tests meshing with an exitnode created with `create-exitnode.sh`.